### PR TITLE
Add server and build script for airline manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+airline-manager/node_modules/

--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ A lightweight browser-based airline manager for tracking your own flight simulat
 2. Add flights using the form. Flights are saved locally so your progress stays on your machine.
 
 Feel free to expand it with additional features like revenue tracking, aircraft maintenance, or route planning.
+
+### Build an Executable
+
+1. Navigate to `airline-manager`.
+2. Run `npm install` to install dependencies.
+3. Run `npm run build-win` to generate `AirlineManager.exe`.

--- a/airline-manager/package.json
+++ b/airline-manager/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "airline-manager",
+  "version": "1.0.0",
+  "description": "Airline manager packaged as executable",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "build-win": "pkg server.js --targets node20-win-x64 --output AirlineManager.exe",
+    "test": "echo 'No tests specified' && exit 0"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "open": "^9.1.0"
+  },
+  "devDependencies": {
+    "pkg": "^5.8.1"
+  }
+}

--- a/airline-manager/server.js
+++ b/airline-manager/server.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const path = require('path');
+const open = require('open');
+
+const app = express();
+const port = 3000;
+
+app.use(express.static(path.join(__dirname)));
+
+app.listen(port, () => {
+  console.log(`Airline Manager running at http://localhost:${port}`);
+  open(`http://localhost:${port}`);
+});


### PR DESCRIPTION
## Summary
- add Node-based static server for airline manager
- include build script to generate Windows executable via pkg
- document executable build steps in README

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden fetching packages)*
- `npm run build-win` *(fails: pkg: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a204d5003c832683f74b2582bb19aa