### PR TITLE
Add Aztec-themed text adventure UI and story

### DIFF
--- a/airline-manager/app.js
+++ b/airline-manager/app.js
@@ -1,55 +1,358 @@
-const storageKey = 'airlineManagerFlights';
-
-function loadFlights() {
-  return JSON.parse(localStorage.getItem(storageKey)) || [];
-}
-
-function saveFlights(flights) {
-  localStorage.setItem(storageKey, JSON.stringify(flights));
-}
-
-function renderFlights() {
-  const flights = loadFlights();
-  const tbody = document.getElementById('flights-table');
-  tbody.innerHTML = '';
-  flights.forEach((flight, index) => {
-    const tr = document.createElement('tr');
-    tr.innerHTML = `
-      <td>${flight.number}</td>
-      <td>${flight.origin}</td>
-      <td>${flight.destination}</td>
-      <td>${flight.aircraft}</td>
-      <td>${flight.date}</td>
-      <td><button data-index="${index}" class="delete">Delete</button></td>
-    `;
-    tbody.appendChild(tr);
-  });
-}
-
-document.getElementById('flight-form').addEventListener('submit', (e) => {
-  e.preventDefault();
-  const flight = {
-    number: document.getElementById('flight-number').value.trim(),
-    origin: document.getElementById('origin').value.trim(),
-    destination: document.getElementById('destination').value.trim(),
-    aircraft: document.getElementById('aircraft').value.trim(),
-    date: document.getElementById('date').value
-  };
-  const flights = loadFlights();
-  flights.push(flight);
-  saveFlights(flights);
-  e.target.reset();
-  renderFlights();
-});
-
-document.getElementById('flights-table').addEventListener('click', (e) => {
-  if (e.target.classList.contains('delete')) {
-    const index = e.target.getAttribute('data-index');
-    const flights = loadFlights();
-    flights.splice(index, 1);
-    saveFlights(flights);
-    renderFlights();
+const story = {
+  nodes: {
+    start: {
+      title: 'Morgen über Tenochtitlan',
+      text: [
+        'Der Nebel steigt von den Kanälen auf, als die Trommeln den Sonnenaufgang begleiten.',
+        'Heute, {name}, sollst du Zeichen der Götter sammeln, bevor die Sonnenfinsternis eintritt.'
+      ],
+      choices: [
+        { label: 'Dem Priester des Sonnentempels folgen', next: 'temple' },
+        { label: 'Mit der Jaguarkriegerin trainieren', next: 'training' },
+        { label: 'Die schwimmenden Gärten erkunden', next: 'canals' }
+      ]
+    },
+    temple: {
+      title: 'Stufen zum Himmel',
+      text: [
+        'Der Priester reicht dir Räucherharz und deutet auf den Altar.',
+        'Der Stein ist warm und wartet auf eine Gabe.'
+      ],
+      choices: [
+        {
+          label: 'Opfere Kakao und erbete eine Vision',
+          next: 'vision',
+          effects: { favor: 1, addItem: 'Sonnenamulett' },
+          log: 'Du legst Kakao auf den Altar und erhältst ein Sonnenamulett.'
+        },
+        {
+          label: 'Bitte um Wissen über die Finsternis',
+          next: 'riddle',
+          log: 'Der Priester erzählt dir ein altes Rätsel über den Schatten.'
+        }
+      ]
+    },
+    riddle: {
+      title: 'Das Rätsel des Schattens',
+      text: [
+        '"Die Sonne ruht nicht, doch ihr Herz sucht Schutz", sagt der Priester.',
+        'Du spürst, dass Mut nötig ist, um das Zeichen zu deuten.'
+      ],
+      choices: [
+        {
+          label: 'Du schwörst, die Stadt zu beschützen',
+          next: 'vision',
+          effects: { courage: 1, favor: 1 },
+          log: 'Dein Schwur erfüllt dich mit Mut und die Sonne erhört dich.'
+        },
+        {
+          label: 'Du gehst und suchst Rat bei den Kriegern',
+          next: 'training'
+        }
+      ]
+    },
+    training: {
+      title: 'Pfad der Jaguarkrieger',
+      text: [
+        'Die Kriegerin Yaqui lächelt, als du die Übungsarena betrittst.',
+        '"Zeig mir, wie du dem Schatten begegnest", fordert sie.'
+      ],
+      choices: [
+        {
+          label: 'Sparring im Sand',
+          next: 'training_result',
+          effects: { courage: 1 },
+          log: 'Der Kampf macht dich schneller und stärkt deinen Mut.'
+        },
+        {
+          label: 'Erzähle von den Zeichen der Sonne',
+          next: 'vision',
+          effects: { favor: 1 },
+          log: 'Yaqui erinnert sich an eine alte Prophezeiung und segnet dich.'
+        }
+      ]
+    },
+    training_result: {
+      title: 'Schweiß und Staub',
+      text: [
+        'Yaqui überreicht dir eine Obsidian-Klinge als Zeichen des Respekts.',
+        '"Nimm sie. Du wirst sie brauchen, wenn der Himmel dunkelt."'
+      ],
+      choices: [
+        {
+          label: 'Zurück zu den Kanälen',
+          next: 'canals',
+          effects: { addItem: 'Obsidian-Klinge' }
+        },
+        {
+          label: 'Direkt zum Sonnentempel',
+          next: 'temple',
+          effects: { addItem: 'Obsidian-Klinge' }
+        }
+      ]
+    },
+    canals: {
+      title: 'Gärten auf dem Wasser',
+      text: [
+        'Du gleitest über die Chinampas. Händler rufen, Kinder lachen.',
+        'Ein Kanu gerät ins Wanken, als dunkle Wolken aufziehen.'
+      ],
+      choices: [
+        {
+          label: 'Rette den Händler und seine Jade',
+          next: 'market_return',
+          effects: { favor: 1, addItem: 'Jade-Siegel' },
+          log: 'Der Händler schenkt dir ein Jade-Siegel als Dank.'
+        },
+        {
+          label: 'Folge einem verborgenen Wasserweg',
+          next: 'island',
+          log: 'Du paddelst in einen stillen Kanal, wo die Luft kühler wird.'
+        }
+      ]
+    },
+    market_return: {
+      title: 'Zurück im Markt',
+      text: [
+        'Der Händler führt dich zu einem Schrein am Markt.',
+        'Du spürst, dass die Zeichen sich sammeln.'
+      ],
+      choices: [
+        {
+          label: 'Die Zeichen im Tempel deuten lassen',
+          next: 'sun_trial'
+        },
+        {
+          label: 'Noch einmal die Krieger aufsuchen',
+          next: 'training'
+        }
+      ]
+    },
+    island: {
+      title: 'Die versunkene Insel',
+      text: [
+        'Im Schilf entdeckst du eine versunkene Insel. Ein Altar mit goldenen Glyphen leuchtet schwach.',
+        'Ein Jaguargeist zeichnet die Luft mit seinem Schweif.'
+      ],
+      choices: [
+        {
+          label: 'Sprich das Gebet des Jaguar',
+          next: 'sun_trial',
+          effects: { courage: 1, addItem: 'Jaguar-Totem' },
+          log: 'Der Geist überlässt dir ein Jaguar-Totem.'
+        },
+        {
+          label: 'Nimm die Glyphen mit und geh',
+          next: 'sun_trial',
+          effects: { favor: 1 },
+          log: 'Die Glyphen glühen in deiner Hand, als du zurückkehrst.'
+        }
+      ]
+    },
+    vision: {
+      title: 'Vision der Fünften Sonne',
+      text: [
+        'Du siehst den Himmel dunkel werden, doch eine goldene Schlange windet sich um die Sonne.',
+        'Nur wer Mut und Gunst sammelt, kann den Schatten abwehren.'
+      ],
+      choices: [
+        {
+          label: 'Bereite dich auf die Prüfung vor',
+          next: 'sun_trial'
+        },
+        {
+          label: 'Suche weiter nach Zeichen in den Kanälen',
+          next: 'canals'
+        }
+      ]
+    },
+    sun_trial: {
+      title: 'Die Sonnenfinsternis',
+      text: [
+        'Die Trommeln verstummen. Der Schatten kriecht über den Kalenderstein.',
+        'Du musst entscheiden, wie du die Stadt schützt.'
+      ],
+      choices: [
+        {
+          label: 'Erhebe das Sonnenamulett und rufe die Götter',
+          next: 'ending_light',
+          requires: { item: 'Sonnenamulett' }
+        },
+        {
+          label: 'Schlage mit der Obsidian-Klinge in die Dunkelheit',
+          next: 'ending_courage',
+          requires: { item: 'Obsidian-Klinge' }
+        },
+        {
+          label: 'Verbinde alle Zeichen zu einem Ritual',
+          next: 'ending_balance',
+          requires: { minFavor: 2 }
+        }
+      ]
+    },
+    ending_light: {
+      title: 'Sieg der Strahlen',
+      text: [
+        'Das Amulett glüht wie flüssiges Gold. Die Sonne bricht durch den Schatten.',
+        'Tenochtitlan jubelt, und dein Name wird in Liedern bewahrt.'
+      ],
+      end: true,
+      log: 'Du rufst die Götter und bringst das Licht zurück.'
+    },
+    ending_courage: {
+      title: 'Mut des Jaguar',
+      text: [
+        'Deine Klinge schneidet in den Schatten. Der Jaguargeist brüllt aus der Dunkelheit.',
+        'Die Menschen sehen deinen Mut und folgen dir in ein neues Zeitalter.'
+      ],
+      end: true,
+      log: 'Dein Mut zerreißt die Finsternis.'
+    },
+    ending_balance: {
+      title: 'Ritual der Harmonie',
+      text: [
+        'Jade, Rauch und Gesang verbinden sich. Der Schatten löst sich im Klang der Trommeln auf.',
+        'Die Götter schenken dir ein Zeichen der Harmonie, und die Stadt bleibt geschützt.'
+      ],
+      end: true,
+      log: 'Du vereinst alle Zeichen und stellst das Gleichgewicht wieder her.'
+    }
   }
+};
+
+const state = {
+  name: 'Reisende',
+  favor: 0,
+  courage: 0,
+  inventory: [],
+  currentNode: null
+};
+
+const nameInput = document.getElementById('player-name');
+const startBtn = document.getElementById('start-btn');
+const restartBtn = document.getElementById('restart-btn');
+const nodeTitle = document.getElementById('node-title');
+const nodeText = document.getElementById('node-text');
+const choicesContainer = document.getElementById('choices');
+const logList = document.getElementById('log');
+const favorValue = document.getElementById('favor');
+const courageValue = document.getElementById('courage');
+const inventoryValue = document.getElementById('inventory');
+
+function resetState() {
+  state.name = nameInput.value.trim() || 'Reisende';
+  state.favor = 0;
+  state.courage = 0;
+  state.inventory = [];
+  state.currentNode = 'start';
+  logList.innerHTML = '';
+}
+
+function updateStatus() {
+  favorValue.textContent = state.favor;
+  courageValue.textContent = state.courage;
+  inventoryValue.textContent = state.inventory.length ? state.inventory.join(', ') : '–';
+}
+
+function applyEffects(effects) {
+  if (!effects) {
+    return;
+  }
+  if (effects.favor) {
+    state.favor += effects.favor;
+  }
+  if (effects.courage) {
+    state.courage += effects.courage;
+  }
+  if (effects.addItem) {
+    if (!state.inventory.includes(effects.addItem)) {
+      state.inventory.push(effects.addItem);
+    }
+  }
+}
+
+function addLogEntry(message) {
+  if (!message) {
+    return;
+  }
+  const li = document.createElement('li');
+  li.textContent = message;
+  logList.prepend(li);
+}
+
+function canChoose(choice) {
+  if (!choice.requires) {
+    return { allowed: true };
+  }
+  if (choice.requires.item && !state.inventory.includes(choice.requires.item)) {
+    return { allowed: false, reason: `Benötigt: ${choice.requires.item}` };
+  }
+  if (choice.requires.minFavor && state.favor < choice.requires.minFavor) {
+    return { allowed: false, reason: `Benötigt Sonnen-Gunst ${choice.requires.minFavor}` };
+  }
+  return { allowed: true };
+}
+
+function renderNode(nodeId) {
+  const node = story.nodes[nodeId];
+  if (!node) {
+    return;
+  }
+  state.currentNode = nodeId;
+  nodeTitle.textContent = node.title;
+  nodeText.innerHTML = '';
+  node.text.forEach((line) => {
+    const p = document.createElement('p');
+    p.textContent = line.replace('{name}', state.name);
+    nodeText.appendChild(p);
+  });
+
+  choicesContainer.innerHTML = '';
+  if (node.end) {
+    const endMessage = document.createElement('p');
+    endMessage.textContent = 'Das Abenteuer ist beendet. Du kannst jederzeit neu beginnen.';
+    nodeText.appendChild(endMessage);
+    updateStatus();
+    addLogEntry(node.log);
+    return;
+  }
+
+  node.choices.forEach((choice) => {
+    const button = document.createElement('button');
+    button.className = 'choice-btn';
+    button.type = 'button';
+    const availability = canChoose(choice);
+    button.textContent = choice.label;
+    if (!availability.allowed) {
+      button.disabled = true;
+      const hint = document.createElement('span');
+      hint.className = 'choice-hint';
+      hint.textContent = availability.reason;
+      button.appendChild(hint);
+    } else {
+      button.addEventListener('click', () => {
+        applyEffects(choice.effects);
+        addLogEntry(choice.log);
+        updateStatus();
+        renderNode(choice.next);
+      });
+    }
+    choicesContainer.appendChild(button);
+  });
+  updateStatus();
+}
+
+startBtn.addEventListener('click', () => {
+  resetState();
+  updateStatus();
+  renderNode(state.currentNode);
 });
 
-renderFlights();
+restartBtn.addEventListener('click', () => {
+  nameInput.value = '';
+  resetState();
+  updateStatus();
+  renderNode(state.currentNode);
+});
+
+updateStatus();

--- a/airline-manager/index.html
+++ b/airline-manager/index.html
@@ -1,32 +1,55 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="de">
 <head>
 <meta charset="UTF-8">
-<title>Airline Manager</title>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Aztekisches Textabenteuer</title>
 <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-<h1>Airline Manager</h1>
-<section id="add-flight">
-<h2>Add Flight</h2>
-<form id="flight-form">
-<input type="text" id="flight-number" placeholder="Flight Number" required>
-<input type="text" id="origin" placeholder="Origin" required>
-<input type="text" id="destination" placeholder="Destination" required>
-<input type="text" id="aircraft" placeholder="Aircraft" required>
-<input type="date" id="date" required>
-<button type="submit">Add Flight</button>
-</form>
-</section>
-<section id="flight-list">
-<h2>Scheduled Flights</h2>
-<table>
-<thead>
-<tr><th>#</th><th>Origin</th><th>Destination</th><th>Aircraft</th><th>Date</th><th>Actions</th></tr>
-</thead>
-<tbody id="flights-table"></tbody>
-</table>
-</section>
+<div class="app">
+  <header>
+    <p class="eyebrow">Kalenderstein der Fünften Sonne</p>
+    <h1>Aztekisches Textabenteuer</h1>
+    <p class="subtitle">Erkunde Tenochtitlan, sammle Zeichen der Götter und entscheide über das Schicksal der Stadt.</p>
+  </header>
+
+  <section class="panel">
+    <div class="controls">
+      <label for="player-name">Dein Name</label>
+      <input id="player-name" type="text" placeholder="z.B. Yaotl">
+      <button id="start-btn" type="button">Abenteuer beginnen</button>
+      <button id="restart-btn" type="button">Neu starten</button>
+    </div>
+    <div class="status">
+      <div>
+        <span class="label">Sonnen-Gunst</span>
+        <span id="favor">0</span>
+      </div>
+      <div>
+        <span class="label">Mut</span>
+        <span id="courage">0</span>
+      </div>
+      <div>
+        <span class="label">Inventar</span>
+        <span id="inventory">–</span>
+      </div>
+    </div>
+  </section>
+
+  <section class="story">
+    <h2 id="node-title">Bereit für deine Reise?</h2>
+    <div id="node-text" class="node-text">
+      <p>Gib deinen Namen ein und beginne ein Abenteuer zwischen Tempeln, Kanälen und den Zeichen der Sonne.</p>
+    </div>
+    <div id="choices" class="choices"></div>
+  </section>
+
+  <section class="log">
+    <h3>Chronik</h3>
+    <ul id="log"></ul>
+  </section>
+</div>
 <script src="app.js"></script>
 </body>
 </html>

--- a/airline-manager/styles.css
+++ b/airline-manager/styles.css
@@ -1,23 +1,171 @@
+:root {
+  color-scheme: light;
+  --obsidian: #1c1a18;
+  --clay: #c56a36;
+  --jade: #2e8f7f;
+  --gold: #d1a84b;
+  --sand: #f3e8d7;
+}
+
+* {
+  box-sizing: border-box;
+}
+
 body {
-  font-family: Arial, sans-serif;
-  margin: 20px;
+  margin: 0;
+  font-family: "Trebuchet MS", "Gill Sans", sans-serif;
+  background: radial-gradient(circle at top, #fef8ef, #f0dfc4 45%, #e2caa3 100%);
+  color: var(--obsidian);
 }
 
-table {
-  border-collapse: collapse;
-  width: 100%;
+.app {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 32px 20px 40px;
+  display: grid;
+  gap: 24px;
 }
 
-th, td {
-  border: 1px solid #ccc;
-  padding: 8px;
-  text-align: left;
+header {
+  text-align: center;
 }
 
-form input {
-  margin-right: 8px;
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.4em;
+  font-size: 0.75rem;
+  color: var(--clay);
+  margin-bottom: 8px;
 }
 
-button {
+h1 {
+  font-size: 2.6rem;
+  margin: 0 0 8px;
+}
+
+.subtitle {
+  font-size: 1.1rem;
+  margin: 0;
+}
+
+.panel {
+  background: rgba(255, 255, 255, 0.85);
+  border: 2px solid var(--clay);
+  border-radius: 16px;
+  padding: 16px 20px;
+  display: grid;
+  gap: 16px;
+}
+
+.controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+}
+
+.controls input {
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--clay);
+  font-size: 1rem;
+  min-width: 180px;
+}
+
+.controls button {
+  background: var(--clay);
+  color: white;
+  border: none;
+  border-radius: 999px;
+  padding: 8px 18px;
+  font-weight: 600;
   cursor: pointer;
+}
+
+.controls button#restart-btn {
+  background: var(--jade);
+}
+
+.status {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+  font-size: 0.95rem;
+}
+
+.status .label {
+  display: block;
+  font-weight: 700;
+  color: var(--clay);
+}
+
+.story {
+  background: white;
+  border-radius: 18px;
+  padding: 22px;
+  box-shadow: 0 10px 30px rgba(40, 25, 10, 0.12);
+}
+
+.node-text p {
+  line-height: 1.6;
+}
+
+.choices {
+  display: grid;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.choice-btn {
+  border: 2px solid var(--gold);
+  background: #fff7e8;
+  padding: 12px 16px;
+  border-radius: 12px;
+  text-align: left;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.choice-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.choice-hint {
+  display: block;
+  font-size: 0.85rem;
+  font-weight: 400;
+  color: #6f5744;
+  margin-top: 4px;
+}
+
+.log {
+  background: rgba(255, 255, 255, 0.78);
+  border-radius: 16px;
+  padding: 16px 20px;
+  border: 1px dashed var(--jade);
+}
+
+.log ul {
+  margin: 0;
+  padding-left: 20px;
+}
+
+.log li {
+  margin-bottom: 6px;
+}
+
+@media (max-width: 640px) {
+  h1 {
+    font-size: 2rem;
+  }
+
+  .controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .controls button {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
### Motivation
- Replace the existing airline manager UI with a small, playable Aztec-themed browser text adventure prototype to provide an immediate interactive demo. 
- Provide a simple branching story engine with persistent state, inventory and conditional choices so the narrative can express consequences and endings. 
- Ship a themed layout and styles so the experience has a clear visual identity and responsive behavior. 

### Description
- Replaced `airline-manager/index.html` with a new layout containing header, player controls, status panel, story area and chronicle (`#log`).
- Rewrote `airline-manager/app.js` to implement a `story` graph and engine including `state`, `resetState`, `applyEffects`, conditional `requires`, choice rendering, and `addLogEntry` for activity logging.
- Restyled the app in `airline-manager/styles.css` with an Aztec-inspired color palette, panel/button styles and responsive rules.
- Removed the previous flight-management form and localStorage flight code and replaced it with the narrative-driven UI and logic. 

### Testing
- Started a static server with `python -m http.server` to serve the files and confirmed the server responded on port 8000. 
- Attempted an automated Playwright run to fill the player name, start the game and capture a screenshot, but the Playwright run failed with timeouts and a Chromium crash (`TargetClosedError` / `SIGSEGV`).
- No unit tests were added or executed; changes were committed to the repository successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a2fdfa3c48326bffd5da8aff2f312)